### PR TITLE
Add `tuc` as Tucuman timezone abbreviation

### DIFF
--- a/includes/_timezones_setup.php
+++ b/includes/_timezones_setup.php
@@ -54,7 +54,7 @@ function parseString($str) {
     $timezone = "Europe/London";
   }
 
-  if (preg_match('/(tucumán|tucuman|argentina|ar|art|luis|pablo|bernardo)$/i', $str)) {
+  if (preg_match('/(tucumán|tucuman|tuc|argentina|ar|art|luis|pablo|bernardo)$/i', $str)) {
     $timezone = "America/Argentina/Tucuman";
   }
 


### PR DESCRIPTION
`TUC` is the airport code used for Tucuman, so thought was worth considering it to the same level as `AR`.

Thank you. ❤️ ❤️ ❤️ 